### PR TITLE
Fixed Talkpower not given when revived during a round

### DIFF
--- a/GMod/lua/autorun/ts3bridge.lua
+++ b/GMod/lua/autorun/ts3bridge.lua
@@ -221,11 +221,20 @@ local function hook_begin_round()
 				mute(victim:SteamID(), victim:IPAddress(), victim:Nick())
 			end
 		)
-		
+				
 		hook.Add( "PlayerSilentDeath", "PlayerSilentDeath_ts3_bridge", 
 			function( ply )
 				mute(ply:SteamID(), ply:IPAddress(), ply:Nick())
 			end
+		)
+		
+		hook.Add( "PlayerChangedTeam", "TeamChange", 
+			function( ply, oldTeam, newTeam )
+				local changedToTeam = team.GetName( newTeam )
+				if changedToTeam == ("Spectators") then  
+					mute(ply:SteamID(), ply:IPAddress(), ply:Nick())
+				end
+			end 
 		)
 	end
 	)
@@ -309,6 +318,9 @@ local function hook_player_spawn()
 						end
 					end
 				)
+				if ply:Team() != 1002 then -- dont unmute when the player spawns as a spectator
+					unmute(ply:SteamID(), ply:IPAddress(), ply:Nick())
+				end
 			end
 		end
 	)


### PR DESCRIPTION
Dieser Fix behebt das Problem, dass ein Spieler keine Talkpower erhält, wenn er in der Runde revived wird, wie es bei dem Defibrillator oder anderen Rollen der Fall ist. 
Zusätzlich habe ich hinzugefügt, dass Spectator keine Talkpower erhalten und beim Wechsel direkt gemutet werden. Dieser Teil ist größtenteils schon durch den PlayerDeath Hook abgedeckt, soll aber garantieren, dass Spieler auch gemutet sind, wenn sie schon als Spectator auf den Server joinen. Sonst kannst du auch nur Zeile 321-323 übernehmen. 